### PR TITLE
Memoize query results

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <meta name="twitter:title" content="Git Author Info">
     <meta name="twitter:description" content="Get the Git username and email address for any GitHub user. Enter a GitHub username to quickly retrieve their author information.">
     <link rel="canonical" href="https://agriyakhetarpal.github.io/git-author-info/">
+    <script src="https://unpkg.com/localstorage-slim@2.7.1/dist/localstorage-slim.js"></script>
     <script defer type="module" src="main.js"></script>
 
     <style>

--- a/main.js
+++ b/main.js
@@ -70,12 +70,24 @@ class HTTPError extends Error {
 }
 
 async function getUserInfo(username) {
+
+  const cacheKey = `github_user_${username}`;
+  const cached = getCached(cacheKey);
+  if (cached) {
+    console.log(`Using cached user info for ${username}`);
+    return cached;
+  }
+
   const response = await fetch(`${GITHUB_API}/users/${username}`);
   const data = await response.json();
   if (!response.ok) {
     console.error("HTTPError", response);
     throw new HTTPError(response.status, data.message || "Unknown error");
   }
+
+  setCached(cacheKey, data);
+  console.log(`Cached user info for ${username}`);
+
   return data;
 }
 

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ let working;
 
 const GITHUB_API = "https://api.github.com";
 
-const CACHE_TTL_SECONDS = 3600
+const CACHE_TTL_SECONDS = 3600;
 
 if (typeof window !== "undefined" && window.ls) {
   window.ls.config.ttl = CACHE_TTL_SECONDS;

--- a/main.js
+++ b/main.js
@@ -99,6 +99,14 @@ async function getUserInfo(username) {
  * @returns {Promise<string[]>} - Array of unique email addresses (real ones, not noreply ones).
  */
 async function getCommitEmail(username) {
+
+  const cacheKey = `github_emails_${username}`;
+  const cached = getCached(cacheKey);
+  if (cached) {
+    console.log(`Using cached commit emails for ${username}`);
+    return cached;
+  }
+
   const emails = new Set();
 
   try {
@@ -168,7 +176,12 @@ async function getCommitEmail(username) {
     console.error("Failed to fetch repos:", err);
   }
 
-  return Array.from(emails);
+  const emailsArray = Array.from(emails);
+
+  setCached(cacheKey, emailsArray);
+  console.log(`Cached commit emails for ${username}`);
+
+  return emailsArray;
 }
 
 /**

--- a/main.js
+++ b/main.js
@@ -13,6 +13,12 @@ let working;
 
 const GITHUB_API = "https://api.github.com";
 
+const CACHE_TTL_SECONDS = 3600
+
+if (typeof window !== "undefined" && window.ls) {
+  window.ls.config.ttl = CACHE_TTL_SECONDS;
+}
+
 function sanitizeString(string) {
   const map = {
     "&": "&amp;",

--- a/main.js
+++ b/main.js
@@ -19,6 +19,35 @@ if (typeof window !== "undefined" && window.ls) {
   window.ls.config.ttl = CACHE_TTL_SECONDS;
 }
 
+/**
+ * Get the cached data for a key.
+ * @param {string} key - Cache key
+ * @returns {*} - Cached value, or null if not found/expired
+ */
+function getCached(key) {
+  try {
+    if (!window.ls) return null;
+    return window.ls.get(key);
+  } catch (err) {
+    console.error("Cache read error:", err);
+    return null;
+  }
+}
+
+/**
+ * Set cached data with TTL.
+ * @param {string} key - Cache key
+ * @param {*} value - Value to cache
+ */
+function setCached(key, value) {
+  try {
+    if (!window.ls) return;
+    window.ls.set(key, value, { ttl: CACHE_TTL_SECONDS });
+  } catch (err) {
+    console.error("Cache write error:", err);
+  }
+}
+
 function sanitizeString(string) {
   const map = {
     "&": "&amp;",


### PR DESCRIPTION
We store them in the browser with a 1-hour TTL to avoid repeated queries. A future improvement could be to allow users to purge their local data with a button.